### PR TITLE
db-dtypes 1.3.0 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+upload_channels:
+  - sfe1ed40
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,12 +28,16 @@ requirements:
     - numpy >=1.16.6
 
 test:
+  source_files:
+    - tests
   imports:
     - db_dtypes
-  commands:
-    - pip check
   requires:
     - pip
+    - pytest
+  commands:
+    - pip check
+    - pytest -v tests
 
 about:
   home: https://github.com/googleapis/python-db-dtypes-pandas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,8 @@ build:
 
 requirements:
   build:
-    - patch     # [not win]
-    - m2-patch  # [win]
+    - patch     # [not win and py<39]
+    - m2-patch  # [win and py<39]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,14 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " test_getitems_when_iter_with_null" %}  # [py<39]
 {% set tests_to_skip = tests_to_skip + " or test_to_numpy" %}                   # [py<39]
 
+# ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
+{% set tests_to_skip = tests_to_skip + " or "test_date_max_2d" %}               # [s390x]
+{% set tests_to_skip = tests_to_skip + " or "test_date_min_2d" %}               # [s390x]
+{% set tests_to_skip = tests_to_skip + " or "test_date_median_2d" %}            # [s390x]
+# AssertionError: assert array(...)
+{% set tests_to_skip = tests_to_skip + " or "test_asdatetime %}                 # [s390x]
+
+
 # pandas 2.0.3 (last py38 build) really doesn't like the JSON
 # compliance tests, 325 of them
 {% set tests_to_ignore = "" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,8 @@ requirements:
 {% set tests_to_skip = tests_to_skip + "test_getitems_when_iter_with_null" %}   # [py<39]
 {% set tests_to_skip = tests_to_skip + " or test_to_numpy" %}                   # [py<39]
 
+{% set tests_to_skip = tests_to_skip + " or " %}                                # [py<39 and s390x]
+
 # ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
 {% set tests_to_skip = tests_to_skip + "test_date_max_2d" %}                    # [s390x]
 {% set tests_to_skip = tests_to_skip + " or test_date_min_2d" %}                # [s390x]
@@ -64,7 +66,8 @@ test:
   commands:
     - pip check
     - pytest -v tests {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})" # [py<39]
-    - pytest -v tests                                                      # [py>=39]
+    - pytest -v tests -k "not ({{ tests_to_skip }})"                       # [py>=39 and s390x]
+    - pytest -v tests                                                      # [py>=39 and not s390x]
 
 about:
   home: https://github.com/googleapis/python-db-dtypes-pandas

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,29 +1,31 @@
 {% set name = "db-dtypes" %}
-{% set version = "1.0.5" %}
+{% set version = "1.3.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/db-dtypes-{{ version }}.tar.gz
-  sha256: ee68f30cbccf343124ef0abebc7f8cc9a74ef8ed7ee4ff61f586117e8040a9d6
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/db_dtypes-{{ version }}.tar.gz
+  sha256: 7bcbc8858b07474dc85b77bb2f3ae488978d1336f5ea73b58c39d9118bc3e91b
 
 build:
-  number: 1
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 0
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.7
+    - python
     - packaging >=17.0
-    - pandas >=0.24.2,<2.0dev
+    - pandas >=0.24.2
     - pyarrow >=3.0.0
-    - numpy >=1.16.6,<2.0dev
+    - numpy >=1.16.6
 
 test:
   imports:
@@ -35,10 +37,14 @@ test:
 
 about:
   home: https://github.com/googleapis/python-db-dtypes-pandas
-  doc_url: https://googleapis.dev/python/db-dtypes/latest/index.html
   summary: Pandas Data Types for SQL systems (BigQuery, Spanner)
+  description: |
+    Pandas extension data types for data from SQL systems such as BigQuery.
   license: Apache-2.0
   license_file: LICENSE
+  license_family: Apache
+  doc_url: https://googleapis.dev/python/db-dtypes/latest/
+  dev_url: https://github.com/googleapis/python-db-dtypes-pandas
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/db_dtypes-{{ version }}.tar.gz
   sha256: 7bcbc8858b07474dc85b77bb2f3ae488978d1336f5ea73b58c39d9118bc3e91b
-  patches:
+  patches:                                                         # [py<39]
     # pandas 2.0.3 (last py38 build) does not support BaseReduceTests
     - patches/0001-remove-test-against-base.BaseReduceTests.patch  # [py<39]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,15 +36,15 @@ requirements:
 # pandas 2.0.3 (last py38 build) doesn't support this attribute
 {% set tests_to_skip = "" %}
 # AttributeError: 'JSONArray' object has no attribute '_data'
-{% set tests_to_skip = tests_to_skip + " test_getitems_when_iter_with_null" %}  # [py<39]
+{% set tests_to_skip = tests_to_skip + "test_getitems_when_iter_with_null" %}   # [py<39]
 {% set tests_to_skip = tests_to_skip + " or test_to_numpy" %}                   # [py<39]
 
 # ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
-{% set tests_to_skip = tests_to_skip + " or "test_date_max_2d" %}               # [s390x]
-{% set tests_to_skip = tests_to_skip + " or "test_date_min_2d" %}               # [s390x]
-{% set tests_to_skip = tests_to_skip + " or "test_date_median_2d" %}            # [s390x]
+{% set tests_to_skip = tests_to_skip + "test_date_max_2d" %}                    # [s390x]
+{% set tests_to_skip = tests_to_skip + " or test_date_min_2d" %}                # [s390x]
+{% set tests_to_skip = tests_to_skip + " or test_date_median_2d" %}             # [s390x]
 # AssertionError: assert array(...)
-{% set tests_to_skip = tests_to_skip + " or "test_asdatetime %}                 # [s390x]
+{% set tests_to_skip = tests_to_skip + " or test_asdatetime" %}                 # [s390x]
 
 
 # pandas 2.0.3 (last py38 build) really doesn't like the JSON

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,9 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/db_dtypes-{{ version }}.tar.gz
   sha256: 7bcbc8858b07474dc85b77bb2f3ae488978d1336f5ea73b58c39d9118bc3e91b
+  patches:
+    # pandas 2.0.3 (last py38 build) does not support BaseReduceTests
+    - patches/0001-remove-test-against-base.BaseReduceTests.patch  # [py<39]
 
 build:
   number: 0
@@ -15,6 +18,9 @@ build:
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
+  build:
+    - patch     # [not win]
+    - m2-patch  # [win]
   host:
     - python
     - pip
@@ -27,6 +33,18 @@ requirements:
     - pyarrow >=3.0.0
     - numpy >=1.16.6
 
+# pandas 2.0.3 (last py38 build) doesn't support this attribute
+{% set tests_to_skip = "" %}
+# AttributeError: 'JSONArray' object has no attribute '_data'
+{% set tests_to_skip = tests_to_skip + " test_getitems_when_iter_with_null" %}  # [py<39]
+{% set tests_to_skip = tests_to_skip + " or test_to_numpy" %}                   # [py<39]
+
+# pandas 2.0.3 (last py38 build) really doesn't like the JSON
+# compliance tests, 325 of them
+{% set tests_to_ignore = "" %}
+# NotImplementedError: <class 'db_dtypes.json.JSONArray'> does not support reshape as backed by a 1D pyarrow.ChunkedArray
+{% set tests_to_ignore = tests_to_ignore + " --ignore=tests/compliance/json/test_json_compliance.py" %}  # [py<39]
+
 test:
   source_files:
     - tests
@@ -37,7 +55,8 @@ test:
     - pytest
   commands:
     - pip check
-    - pytest -v tests
+    - pytest -v tests {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})" # [py<39]
+    - pytest -v tests                                                      # [py>=39]
 
 about:
   home: https://github.com/googleapis/python-db-dtypes-pandas

--- a/recipe/patches/0001-remove-test-against-base.BaseReduceTests.patch
+++ b/recipe/patches/0001-remove-test-against-base.BaseReduceTests.patch
@@ -1,0 +1,27 @@
+From f655709f62c23d7651ec3d444a6d18f7e4cffe88 Mon Sep 17 00:00:00 2001
+From: Ian Fitchet <ifitchet@anaconda.com>
+Date: Mon, 16 Sep 2024 16:42:01 +0100
+Subject: [PATCH] remove test against base.BaseReduceTests
+
+---
+ tests/compliance/json/test_json_compliance.py | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/tests/compliance/json/test_json_compliance.py b/tests/compliance/json/test_json_compliance.py
+index 18610a0..61348d0 100644
+--- a/tests/compliance/json/test_json_compliance.py
++++ b/tests/compliance/json/test_json_compliance.py
+@@ -238,10 +238,6 @@ class TestJSONArrayPrinting(base.BasePrintingTests):
+     pass
+ 
+ 
+-class TestJSONArrayReduce(base.BaseReduceTests):
+-    pass
+-
+-
+ class TestJSONArrayReshaping(base.BaseReshapingTests):
+     @pytest.mark.skip(reason="2D support not implemented for JSONArray")
+     def test_transpose(self, data):
+-- 
+2.39.3 (Apple Git-146)
+

--- a/recipe/patches/0001-remove-test-against-base.BaseReduceTests.patch
+++ b/recipe/patches/0001-remove-test-against-base.BaseReduceTests.patch
@@ -3,6 +3,8 @@ From: Ian Fitchet <ifitchet@anaconda.com>
 Date: Mon, 16 Sep 2024 16:42:01 +0100
 Subject: [PATCH] remove test against base.BaseReduceTests
 
+pandas 2.0.3 (last py38 build) does not support BaseReduceTests
+
 ---
  tests/compliance/json/test_json_compliance.py | 4 ----
  1 file changed, 4 deletions(-)


### PR DESCRIPTION
db-dtypes 1.3.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-5616]
- dev_url:        https://github.com/googleapis/python-db-dtypes-pandas/tree/v1.3.0
- conda_forge:    https://github.com/conda-forge/db-dtypes-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/db-dtypes/1.3.0
- pypi inspector: https://inspector.pypi.io/project/db-dtypes/1.3.0

### Explanation of changes:

- feedstock added to aggregate
- basic build
- upstream tests
  - `py38`'s latest `pandas` `2.0.3` does not support `base.BaseReduceTests`
    - actually, it doesn't like the JSON compliance tests at all...
  - `s390x`: skip some array comparison tests


[PKG-5616]: https://anaconda.atlassian.net/browse/PKG-5616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ