### PR TITLE
PKG-8100: db-dtypes 1.3.0 (py313 rebuild)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,9 +38,6 @@ requirements:
 # AttributeError: 'JSONArray' object has no attribute '_data'
 {% set tests_to_skip = tests_to_skip + "test_getitems_when_iter_with_null" %}   # [py<39]
 {% set tests_to_skip = tests_to_skip + " or test_to_numpy" %}                   # [py<39]
-
-{% set tests_to_skip = tests_to_skip + " or " %}                                # [py<39]
-
 # pandas 2.0.3 (last py38 build) really doesn't like the JSON
 # compliance tests, 325 of them
 {% set tests_to_ignore = "" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     - patches/0001-remove-test-against-base.BaseReduceTests.patch  # [py<39]
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
@@ -39,15 +39,7 @@ requirements:
 {% set tests_to_skip = tests_to_skip + "test_getitems_when_iter_with_null" %}   # [py<39]
 {% set tests_to_skip = tests_to_skip + " or test_to_numpy" %}                   # [py<39]
 
-{% set tests_to_skip = tests_to_skip + " or " %}                                # [py<39 and s390x]
-
-# ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
-{% set tests_to_skip = tests_to_skip + "test_date_max_2d" %}                    # [s390x]
-{% set tests_to_skip = tests_to_skip + " or test_date_min_2d" %}                # [s390x]
-{% set tests_to_skip = tests_to_skip + " or test_date_median_2d" %}             # [s390x]
-# AssertionError: assert array(...)
-{% set tests_to_skip = tests_to_skip + " or test_asdatetime" %}                 # [s390x]
-
+{% set tests_to_skip = tests_to_skip + " or " %}                                # [py<39]
 
 # pandas 2.0.3 (last py38 build) really doesn't like the JSON
 # compliance tests, 325 of them
@@ -66,8 +58,7 @@ test:
   commands:
     - pip check
     - pytest -v tests {{ tests_to_ignore }} -k "not ({{ tests_to_skip }})" # [py<39]
-    - pytest -v tests -k "not ({{ tests_to_skip }})"                       # [py>=39 and s390x]
-    - pytest -v tests                                                      # [py>=39 and not s390x]
+    - pytest -v tests                                                      # [py>=39]
 
 about:
   home: https://github.com/googleapis/python-db-dtypes-pandas


### PR DESCRIPTION
db-dtypes 1.3.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-8100]() 
- [Upstream repository](https://github.com/googleapis/python-db-dtypes-pandas/tree/v1.3.0)

### Explanation of changes:

- py313 rebuild


[PKG-8100]: https://anaconda.atlassian.net/browse/PKG-8100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ